### PR TITLE
Improve thread utilization by fixing an incorrect capacity setting

### DIFF
--- a/src/GraphGen_notSorted.cpp
+++ b/src/GraphGen_notSorted.cpp
@@ -145,7 +145,7 @@ bool GraphGen_notSorted::GenerateGraph(
 
 		threadsafe_queue<Square> rec_queue;
 		threadsafe_queue< std::vector<Edge> > EV_queue;
-		capacity_controller<long long> capacityGate(static_cast<long long>(standardCapacity), 0);
+		capacity_controller<long long> capacityGate(static_cast<long long>(standardCapacity * nCPUWorkerThreads), 0);
 
 		for( auto& rec: squares )
 			rec_queue.push(rec);


### PR DESCRIPTION
I noticed that not all threads were working during graph generation.
This was because the per-thread capacity (`standardCapacity` variable) was incorrectly specified as the global capacity, which is shared by all threads.

This fix improved overall performance by about 3x in my use case.